### PR TITLE
fix(lyrics): 修复 SPlayer-Next 逐行变逐字的问题；延迟获取歌词等待更优结果

### DIFF
--- a/MediaIsland.Tests/Lyrics/SPlayerNextLyricsClientTests.cs
+++ b/MediaIsland.Tests/Lyrics/SPlayerNextLyricsClientTests.cs
@@ -64,6 +64,133 @@ public class SPlayerNextLyricsClientTests
     }
 
     [Fact]
+    public void IsLineLyricsOnly_ReturnsTrue_WhenSourceFormatIsLrc()
+    {
+        var snapshot = new SPlayerNextLyricsClient.SPlayerLyricsSnapshot
+        {
+            Lyric =
+            [
+                new SPlayerNextLyricsClient.SPlayerLyricLine
+                {
+                    Words =
+                    [
+                        new SPlayerNextLyricsClient.SPlayerLyricWord { Word = "A", StartTime = 0, EndTime = 100 },
+                        new SPlayerNextLyricsClient.SPlayerLyricWord { Word = "B", StartTime = 100, EndTime = 200 }
+                    ]
+                }
+            ],
+            Source = new SPlayerNextLyricsClient.SPlayerLyricSource { Format = "lrc" }
+        };
+
+        Assert.True(SPlayerNextLyricsClient.IsLineLyricsOnly(snapshot));
+    }
+
+    [Fact]
+    public void IsLineLyricsOnly_ReturnsTrue_WhenEveryLineHasSingleWord()
+    {
+        var snapshot = new SPlayerNextLyricsClient.SPlayerLyricsSnapshot
+        {
+            Lyric =
+            [
+                new SPlayerNextLyricsClient.SPlayerLyricLine
+                {
+                    Words =
+                    [
+                        new SPlayerNextLyricsClient.SPlayerLyricWord { Word = "A", StartTime = 0, EndTime = 100 }
+                    ]
+                },
+                new SPlayerNextLyricsClient.SPlayerLyricLine
+                {
+                    Words =
+                    [
+                        new SPlayerNextLyricsClient.SPlayerLyricWord { Word = "B", StartTime = 100, EndTime = 200 }
+                    ]
+                }
+            ],
+            Source = new SPlayerNextLyricsClient.SPlayerLyricSource { Format = null }
+        };
+
+        Assert.True(SPlayerNextLyricsClient.IsLineLyricsOnly(snapshot));
+    }
+
+    [Fact]
+    public void IsLineLyricsOnly_ReturnsTrue_WhenEmptyWordLinesPresent()
+    {
+        var snapshot = new SPlayerNextLyricsClient.SPlayerLyricsSnapshot
+        {
+            Lyric =
+            [
+                new SPlayerNextLyricsClient.SPlayerLyricLine
+                {
+                    TranslatedLyric = "纯翻译行",
+                    Words = null
+                },
+                new SPlayerNextLyricsClient.SPlayerLyricLine
+                {
+                    Words =
+                    [
+                        new SPlayerNextLyricsClient.SPlayerLyricWord { Word = "A", StartTime = 0, EndTime = 100 }
+                    ]
+                }
+            ]
+        };
+
+        Assert.True(SPlayerNextLyricsClient.IsLineLyricsOnly(snapshot));
+    }
+
+    [Fact]
+    public void IsLineLyricsOnly_ReturnsFalse_WhenSomeLineHasMultipleWords()
+    {
+        var snapshot = new SPlayerNextLyricsClient.SPlayerLyricsSnapshot
+        {
+            Lyric =
+            [
+                new SPlayerNextLyricsClient.SPlayerLyricLine
+                {
+                    Words =
+                    [
+                        new SPlayerNextLyricsClient.SPlayerLyricWord { Word = "A", StartTime = 0, EndTime = 100 }
+                    ]
+                },
+                new SPlayerNextLyricsClient.SPlayerLyricLine
+                {
+                    Words =
+                    [
+                        new SPlayerNextLyricsClient.SPlayerLyricWord { Word = "B", StartTime = 100, EndTime = 150 },
+                        new SPlayerNextLyricsClient.SPlayerLyricWord { Word = "C", StartTime = 150, EndTime = 200 }
+                    ]
+                }
+            ],
+            Source = new SPlayerNextLyricsClient.SPlayerLyricSource { Format = null }
+        };
+
+        Assert.False(SPlayerNextLyricsClient.IsLineLyricsOnly(snapshot));
+    }
+
+    [Fact]
+    public void IsLineLyricsOnly_ReturnsFalse_ForWordSyncedYrcSource()
+    {
+        // YRC 是逐字格式（MapFormat 映射为 Lrc），按原始 format 字符串不应误判为逐行。
+        var snapshot = new SPlayerNextLyricsClient.SPlayerLyricsSnapshot
+        {
+            Lyric =
+            [
+                new SPlayerNextLyricsClient.SPlayerLyricLine
+                {
+                    Words =
+                    [
+                        new SPlayerNextLyricsClient.SPlayerLyricWord { Word = "A", StartTime = 0, EndTime = 100 },
+                        new SPlayerNextLyricsClient.SPlayerLyricWord { Word = "B", StartTime = 100, EndTime = 200 }
+                    ]
+                }
+            ],
+            Source = new SPlayerNextLyricsClient.SPlayerLyricSource { Format = "yrc" }
+        };
+
+        Assert.False(SPlayerNextLyricsClient.IsLineLyricsOnly(snapshot));
+    }
+
+    [Fact]
     public void IsSameTrack_MatchesTitleAndOverlappingArtists()
     {
         var media = new MediaInfo(

--- a/MediaIsland/Services/Lyrics/Providers/SPlayerNextLyricsClient.cs
+++ b/MediaIsland/Services/Lyrics/Providers/SPlayerNextLyricsClient.cs
@@ -27,6 +27,12 @@ public sealed class SPlayerNextLyricsClient(ILogger<SPlayerNextLyricsClient>? lo
     private const int MaxFetchAttempts = 5;
     private static readonly TimeSpan FetchRetryDelay = TimeSpan.FromSeconds(1);
 
+    /// <summary>
+    /// 切歌后 SPlayer-Next 可能仍在解析更佳歌词，默认先等待 2 秒再获取，
+    /// 避免 MediaIsland 抢先拿到过渡歌词。
+    /// </summary>
+    private static readonly TimeSpan InitialFetchDelay = TimeSpan.FromSeconds(2);
+
     private static readonly HttpClient HttpClient = LyricsHttp.CreateClient("splayer-next");
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -48,6 +54,9 @@ public sealed class SPlayerNextLyricsClient(ILogger<SPlayerNextLyricsClient>? lo
         {
             return null;
         }
+
+        // 默认延迟后再首次获取，给 SPlayer-Next 时间解析出更佳歌词。
+        await Task.Delay(InitialFetchDelay, cancellationToken).ConfigureAwait(false);
 
         for (var attempt = 1; attempt <= MaxFetchAttempts; attempt++)
         {
@@ -126,8 +135,8 @@ public sealed class SPlayerNextLyricsClient(ILogger<SPlayerNextLyricsClient>? lo
                 : media.Duration;
             var trackId = FirstNonEmpty(snapshot.TrackId, track?.Id) ?? title;
             var offsetMs = snapshot.LyricOffsetMs;
-            // 保留 API 解析出的逐字信息；组件侧再按全局开关折叠显示。
-            const bool preferWordSync = true;
+            // LRC 来源或每行仅一个词片段时是逐行歌词，不启用逐字同步。
+            var preferWordSync = !IsLineLyricsOnly(snapshot);
 
             var lines = ConvertLines(snapshot.Lyric, offsetMs);
             if (lines.Count == 0)
@@ -253,6 +262,22 @@ public sealed class SPlayerNextLyricsClient(ILogger<SPlayerNextLyricsClient>? lo
                 left.Equals(right, StringComparison.OrdinalIgnoreCase) ||
                 left.Contains(right, StringComparison.OrdinalIgnoreCase) ||
                 right.Contains(left, StringComparison.OrdinalIgnoreCase)));
+    }
+
+    /// <summary>
+    /// 判断外部 API 返回的歌词是否为逐行歌词（非逐字）：
+    /// 1) source.format 为 lrc；2) 所有行的词片段数均不超过 1。
+    /// 这两种情况不具备逐字信息，不应启用逐字同步。
+    /// </summary>
+    internal static bool IsLineLyricsOnly(SPlayerLyricsSnapshot snapshot)
+    {
+        if (string.Equals(snapshot.Source?.Format, "lrc", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return snapshot.Lyric is { Count: > 0 } &&
+               snapshot.Lyric.All(line => (line.Words?.Count ?? 0) <= 1);
     }
 
     internal static IReadOnlyList<LyricsLine> ConvertLines(


### PR DESCRIPTION
## 概述

修复从 SPlayer-Next 外部 API 获取的逐行歌词被误判为逐字歌词的问题，并为首次获取增加默认延迟，避免抢到 SPlayer-Next 尚未解析完成的过渡歌词。

## 变更内容

1. **逐行歌词判定（不启用逐字同步）**
- 当歌词 `source.format` 为 `lrc` 时，视为逐行歌词，不适用逐字歌词功能；
- 当所有行的词片段数均不超过 1 时（部分 QRC / YRC 歌词可能也是逐行），同样视为逐行歌词；
- 基于原始 format 字符串判断，逐字格式 `yrc`/`qrc`/`ttml` 不受影响。

2. **默认延迟 2 秒获取**
- 首次从 SPlayer-Next 外部 API 获取歌词前默认等待 2 秒，给 SPlayer-Next 时间解析出更佳歌词；
- 不新增设置项，重试逻辑（5 次 × 1 秒间隔）保持不变。

## 文件变更

| 文件 | 说明 |
| --- | --- |
| `MediaIsland/Services/Lyrics/Providers/SPlayerNextLyricsClient.cs` | 新增 `IsLineLyricsOnly` 判定与 2 秒初始延迟 |
| `MediaIsland.Tests/Lyrics/SPlayerNextLyricsClientTests.cs` | 新增 5 个 `IsLineLyricsOnly` 单元测试 |